### PR TITLE
Add asynchronous event listener support for onBeforeSend

### DIFF
--- a/global/index.d.ts
+++ b/global/index.d.ts
@@ -178,7 +178,10 @@ declare namespace browser.compose {
   ) => {
     cancel?: boolean;
     details?: ComposeDetails;
-  }>; // NOTE: Added in Thunderbird 74
+  } | Promise<{
+    cancel?: boolean;
+    details?: ComposeDetails;
+  }>>; // NOTE: Added in Thunderbird 74
 }
 
 declare namespace browser.composeAction {


### PR DESCRIPTION
`onBeforeSend` API accepts async (Promise return) function for blocking, so I have added support for.
(https://bugzilla.mozilla.org/show_bug.cgi?id=1532528)